### PR TITLE
feat: improve clickhouse_service and add pytest config

### DIFF
--- a/cross_dock/services/clickhouse_service.py
+++ b/cross_dock/services/clickhouse_service.py
@@ -56,7 +56,7 @@ def get_clickhouse_client() -> Client:
         logger.debug("ClickHouse client disconnected")
 
 
-def query_supplier_data(brand: str, sku: str, supplier_list: str, limit: int = 3) -> pd.DataFrame:
+def query_supplier_data(brand: str, sku: str, supplier_list: str) -> pd.DataFrame:
     """
     Query ClickHouse for supplier data for a specific brand and SKU.
 
@@ -64,10 +64,10 @@ def query_supplier_data(brand: str, sku: str, supplier_list: str, limit: int = 3
         brand: Product brand
         sku: Product SKU (Stock Keeping Unit) - equivalent to article number in the database
         supplier_list: Supplier list to query (e.g., 'Группа для проценки ТРЕШКА', 'ОПТ-2')
-        limit: Maximum number of suppliers to return (default: 3)
 
     Returns:
         DataFrame with supplier data sorted by price (price, quantity, supplier_name)
+        Limited to 3 suppliers maximum
 
     Raises:
         Exception: If there's an error executing the query
@@ -155,20 +155,19 @@ def query_supplier_data(brand: str, sku: str, supplier_list: str, limit: int = 3
             rank = 1
         ORDER BY
             price ASC
-        LIMIT %(limit)s;
+        LIMIT 3;
         """
 
         query_params = {
             "sku_lower": sku.lower(),
             "brand_values": brand_values,
             "supplier_ids": supplier_ids,
-            "limit": limit,
         }
 
         try:
             with get_clickhouse_client() as client:
                 logger.info(
-                    f"Executing price query with params: sku={sku.lower()}, brands={brand_values}, supplier_count={len(supplier_ids)}, limit={limit}"
+                    f"Executing price query with params: sku={sku.lower()}, brands={brand_values}, supplier_count={len(supplier_ids)}"
                 )
                 result = client.execute(price_query, query_params)
                 logger.info(f"Query executed successfully, got {len(result)} results")

--- a/cross_dock/services/clickhouse_service.py
+++ b/cross_dock/services/clickhouse_service.py
@@ -56,7 +56,7 @@ def get_clickhouse_client() -> Client:
         logger.debug("ClickHouse client disconnected")
 
 
-def query_supplier_data(brand: str, sku: str, supplier_list: str) -> pd.DataFrame:
+def query_supplier_data(brand: str, sku: str, supplier_list: str, days_lookback: int = 2) -> pd.DataFrame:
     """
     Query ClickHouse for supplier data for a specific brand and SKU.
 
@@ -64,6 +64,7 @@ def query_supplier_data(brand: str, sku: str, supplier_list: str) -> pd.DataFram
         brand: Product brand
         sku: Product SKU (Stock Keeping Unit) - equivalent to article number in the database
         supplier_list: Supplier list to query (e.g., 'Группа для проценки ТРЕШКА', 'ОПТ-2')
+        days_lookback: Number of days to look back for supplier data (default: 2)
 
     Returns:
         DataFrame with supplier data sorted by price (price, quantity, supplier_name)
@@ -72,7 +73,9 @@ def query_supplier_data(brand: str, sku: str, supplier_list: str) -> pd.DataFram
     Raises:
         Exception: If there's an error executing the query
     """
-    logger.info(f"Querying supplier data for {brand}/{sku} with supplier list {supplier_list}")
+    logger.info(
+        f"Querying supplier data for {brand}/{sku} with supplier list {supplier_list}, days_lookback={days_lookback}"
+    )
 
     host = getattr(settings, "CLICKHOUSE_HOST", DEFAULT_CLICKHOUSE_HOST)
     user = getattr(settings, "CLICKHOUSE_USER", DEFAULT_CLICKHOUSE_USER)
@@ -132,7 +135,7 @@ def query_supplier_data(brand: str, sku: str, supplier_list: str) -> pd.DataFram
             WHERE
                 lower(df.a) = %(sku_lower)s
                 AND lower(df.b) IN %(brand_values)s
-                AND df.dateupd >= now() - interval 2 day
+                AND df.dateupd >= now() - interval %(days_lookback)s day
                 AND df.supid IN %(supplier_ids)s
                 AND df.q > 0
         ),
@@ -162,12 +165,13 @@ def query_supplier_data(brand: str, sku: str, supplier_list: str) -> pd.DataFram
             "sku_lower": sku.lower(),
             "brand_values": brand_values,
             "supplier_ids": supplier_ids,
+            "days_lookback": days_lookback,
         }
 
         try:
             with get_clickhouse_client() as client:
                 logger.info(
-                    f"Executing price query with params: sku={sku.lower()}, brands={brand_values}, supplier_count={len(supplier_ids)}"
+                    f"Executing price query with params: sku={sku.lower()}, brands={brand_values}, supplier_count={len(supplier_ids)}, days_lookback={days_lookback}, limit=3"
                 )
                 result = client.execute(price_query, query_params)
                 logger.info(f"Query executed successfully, got {len(result)} results")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+"""
+Global pytest configuration file.
+
+This file configures pytest behavior for all test runs in the project.
+It automatically enables verbose mode (-v) for all pytest runs without
+having to specify it on the command line.
+
+To disable verbose mode for a specific run, use:
+    pytest --no-verbose
+
+This is useful for CI/CD pipelines or when you want less output.
+"""
+
+
+def pytest_addoption(parser):
+    """Add command-line options to pytest."""
+    parser.addoption(
+        "--no-verbose",
+        action="store_true",
+        default=False,
+        help="Disable verbose output (override default verbose mode)",
+    )
+
+
+def pytest_configure(config):
+    """Configure pytest before test collection."""
+    # If --no-verbose is not specified, add -v to the command line arguments
+    if not config.getoption("--no-verbose"):
+        config.option.verbose = True


### PR DESCRIPTION
- Remove unnecessary limit parameter from query_supplier_data function
- Replace parameterized LIMIT with hardcoded LIMIT 3 in SQL query
- Make time interval configurable with days_lookback parameter
- Add conftest.py with default verbose mode for pytest

The limit parameter was removed to avoid technical debt since we always use a fixed limit of 3.
The days_lookback parameter (default: 2) allows configuring how far back to look for supplier
data, which will enable a future frontend feature for users to select time ranges from 1-5 days.
The basic conftest.py ensures pytest always runs in verbose mode by default.