### PR TITLE
fix: add db fixture to conftest file

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+import pytest
+
+"""
+Global pytest configuration file.
+
+This file configures pytest behavior for all test runs in the project.
+It automatically enables verbose mode (-v) for all pytest runs without
+having to specify it on the command line.
+
+To disable verbose mode for a specific run, use:
+    pytest --no-verbose
+
+This is useful for CI/CD pipelines or when you want less output.
+"""
+
+
+def pytest_addoption(parser):
+    """Add command-line options to pytest."""
+    parser.addoption(
+        "--no-verbose",
+        action="store_true",
+        default=False,
+        help="Disable verbose output (override default verbose mode)",
+    )
+
+
+def pytest_configure(config):
+    """Configure pytest before test collection."""
+    # If --no-verbose is not specified, add -v to the command line arguments
+    if not config.getoption("--no-verbose"):
+        config.option.verbose = True
+
+
+@pytest.fixture(autouse=True)
+# using aaa in name to make sure this fixture always runs first due to some alphabetical order in certain cases
+def aaa_db(db):
+    pass

--- a/tests/cross_dock/test_celery_views.py
+++ b/tests/cross_dock/test_celery_views.py
@@ -33,7 +33,6 @@ def excel_file():
     )
 
 
-@pytest.mark.django_db
 def test_process_file_view_with_celery(client, authenticated_user, excel_file):
     """Test that the process_file view creates a task and submits a Celery task."""
     with (
@@ -73,7 +72,6 @@ def test_process_file_view_with_celery(client, authenticated_user, excel_file):
         assert "file_path" in kwargs
 
 
-@pytest.mark.django_db
 def test_process_file_view_db_error(client, authenticated_user, excel_file):
     """Test that the process_file view handles database connection errors."""
     with (
@@ -101,7 +99,6 @@ def test_process_file_view_db_error(client, authenticated_user, excel_file):
         mock_remove.assert_called_once()
 
 
-@pytest.mark.django_db
 def test_task_detail_view(client, authenticated_user):
     """Test the task_detail view."""
     # Create a task
@@ -130,7 +127,6 @@ def test_task_detail_view(client, authenticated_user):
     assert "Success" in content
 
 
-@pytest.mark.django_db
 def test_task_detail_view_add_comment(client, authenticated_user):
     """Test adding a comment to a task."""
     # Create a task

--- a/tests/cross_dock/test_tasks.py
+++ b/tests/cross_dock/test_tasks.py
@@ -50,7 +50,6 @@ def task_record():
     user.delete()
 
 
-@pytest.mark.django_db
 def test_process_file_task_success(sample_excel_file, task_record):
     """Test successful file processing."""
     with mock.patch("cross_dock.services.excel_service.process_cross_dock_data_from_file") as mock_process:
@@ -71,7 +70,6 @@ def test_process_file_task_success(sample_excel_file, task_record):
         assert task_record.result_url is not None
 
 
-@pytest.mark.django_db
 def test_process_file_task_failure(sample_excel_file, task_record):
     """Test file processing failure."""
     with mock.patch("cross_dock.tasks.process_cross_dock_data_from_file") as mock_process:

--- a/tests/cross_dock/test_views.py
+++ b/tests/cross_dock/test_views.py
@@ -121,7 +121,6 @@ class TestProcessFileValidation:
 class TestProcessFileSuccess:
     """Tests for successful process_file execution."""
 
-    @pytest.mark.django_db
     @mock.patch("cross_dock.views.process_file_task.delay")
     @mock.patch("cross_dock.views.CrossDockTask.objects.create")
     def test_file_upload_creates_task_and_redirects(


### PR DESCRIPTION
- Create conftest.py in tests directory with autouse db fixture
- Remove @pytest.mark.django_db decorators from test files:
  - tests/cross_dock/test_tasks.py
  - tests/cross_dock/test_celery_views.py
  - tests/cross_dock/test_views.py

This ensures all tests have database access without needing to add the decorator to each test function.

Fixes #13