### PR TITLE
feat(pricelens): add search functionality to cadence page

### DIFF
--- a/pricelens/templates/pricelens/cadence.html
+++ b/pricelens/templates/pricelens/cadence.html
@@ -29,6 +29,13 @@
 
     <div class="card bg-base-100 shadow-xl">
         <div class="card-body p-4">
+            <form method="get" class="mb-4">
+                <div class="join w-full">
+                    <input type="hidden" name="bucket" value="{{ current_bucket }}">
+                    <input type="text" name="q" placeholder="Поиск по ID или имени поставщика..." class="input input-bordered join-item w-full" value="{{ request.GET.q }}">
+                    <button type="submit" class="btn btn-primary join-item">Поиск</button>
+                </div>
+            </form>
             <div class="overflow-x-auto">
                 <table class="table w-full">
                     <thead>


### PR DESCRIPTION
Fixes https://github.com/igorsimb/admin2/issues/43 This commit introduces a search bar on the cadence page, allowing users to filter the list of supplier profiles.

The search functionality enables filtering by either supplier ID or supplier name using a single input field, improving user experience. The backend has been updated to use Django's Q objects for performing the query on both fields simultaneously.